### PR TITLE
Add User Object to Session Storage & Remove It From UserList

### DIFF
--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -15,7 +15,18 @@ const getUsers = async function() {
       body: params
     }).then(response => response.text())
     .then((usersList) => {
-      sessionStorage.setItem("userList", usersList);
+      let users = JSON.parse(usersList);
+      let email = sessionStorage.getItem("email");
+      let newUserList = [];
+      for(let i = 0; i < users.length; i++)
+      {
+        let user = users[i];
+        if(user.email == email)
+          sessionStorage.setItem("user", JSON.stringify(user));
+        else
+          newUserList.push(user);
+      }
+      sessionStorage.setItem("userList", JSON.stringify(newUserList));
     });
 }
 

--- a/target/classes/META-INF/resources/main.js
+++ b/target/classes/META-INF/resources/main.js
@@ -15,7 +15,18 @@ const getUsers = async function() {
       body: params
     }).then(response => response.text())
     .then((usersList) => {
-      sessionStorage.setItem("userList", usersList);
+      let users = JSON.parse(usersList);
+      let email = sessionStorage.getItem("email");
+      let newUserList = [];
+      for(let i = 0; i < users.length; i++)
+      {
+        let user = users[i];
+        if(user.email == email)
+          sessionStorage.setItem("user", JSON.stringify(user));
+        else
+          newUserList.push(user);
+      }
+      sessionStorage.setItem("userList", JSON.stringify(newUserList));
     });
 }
 


### PR DESCRIPTION
I added code in the "getUsers()" method which parses the userList, finds the current user by looking for a user with the same email as the email stored in session storage, and adds the user's object as "user" in session storage and adds a list of users (excluding the current user) as "userList". This will be helpful for cases where the current user's information or the information of all other users' is required.